### PR TITLE
Fix: 중복 게시글 필터링

### DIFF
--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -39,6 +39,7 @@ export function FeedWithGps({ position }: FeedWithGpsProps) {
   const observer = useRef<IntersectionObserver | null>(null);
   const [cursor, setCursor] = useState("");
   const posts = useRef<PostApiSchema["getPostList"]["response"]["results"]>([]);
+  const postIdSet = useRef<Set<number>>(new Set());
   const updatedAt = useRef<number>(0);
 
   const {
@@ -54,7 +55,10 @@ export function FeedWithGps({ position }: FeedWithGpsProps) {
 
   if (updatedAt.current !== dataUpdatedAt) {
     updatedAt.current = dataUpdatedAt;
-    posts.current = [...posts.current, ...(feedList?.results ?? [])];
+    const addedPosts =
+      feedList?.results.filter(({ id }) => !postIdSet.current.has(id)) ?? [];
+    posts.current = [...posts.current, ...addedPosts];
+    addedPosts.forEach(({ id }) => postIdSet.current.add(id));
   }
 
   useEffect(() => {
@@ -121,7 +125,7 @@ export function FeedWithGps({ position }: FeedWithGpsProps) {
                 return (
                   <Post
                     {...post}
-                    key={imageUrl}
+                    key={id}
                     isOdd={index % 2 !== 0}
                     onClick={() => navigate(`/feed/${id}`)}
                   />


### PR DESCRIPTION
원인은 파악이 안 됐지만 서버에서 거리 기준으로 정렬해서 게시글 보내줄 때 가끔 중복되는 게시글이 포함되는 경우가 있어서, 해당 게시글들을 필터링해주는 로직을 추가합니다.